### PR TITLE
Associations

### DIFF
--- a/src/associations.rs
+++ b/src/associations.rs
@@ -1,0 +1,71 @@
+use std::any::{Any, TypeId};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use crate::{manifest, persist, Manifest, Persist};
+
+pub fn association<T: Manifest<AssociationsConn = T::Conn> + Persist + 'static>(
+    associations: &mut Associations<T::Conn>,
+) -> T {
+    let entity = manifest::<T>();
+
+    associations.persist::<T, _>(move |conn| {
+        Box::pin(async move {
+            let entity = persist::<T>(conn).await.map_err(|_| "failed to persist")?;
+
+            Ok(entity)
+        })
+    });
+
+    entity
+}
+
+pub(crate) struct AnyAssociation<Conn> {
+    entity_type: TypeId,
+    pub(crate) persist: Box<
+        dyn FnOnce(
+            Arc<Conn>,
+        ) -> Pin<
+            Box<dyn Future<Output = Result<Box<dyn Any>, Box<dyn std::error::Error>>>>,
+        >,
+    >,
+}
+
+pub struct Associations<Conn> {
+    pub(crate) associations: Vec<AnyAssociation<Conn>>,
+}
+
+impl<Conn: 'static> Associations<Conn> {
+    pub fn new() -> Self {
+        Self {
+            associations: Vec::new(),
+        }
+    }
+
+    pub(crate) fn persist<
+        T: 'static,
+        F: FnOnce(
+                Arc<Conn>,
+            )
+                -> Pin<Box<dyn Future<Output = Result<T, Box<dyn std::error::Error>>>>>
+            + 'static,
+    >(
+        &mut self,
+        persist: F,
+    ) {
+        self.associations.push(AnyAssociation {
+            entity_type: TypeId::of::<T>(),
+            persist: Box::new(|conn| {
+                Box::pin(async move {
+                    let value = persist(conn).await?;
+
+                    Ok(Box::new(value) as Box<dyn Any>)
+                })
+                    as Pin<
+                        Box<dyn Future<Output = Result<Box<dyn Any>, Box<dyn std::error::Error>>>>,
+                    >
+            }),
+        });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,7 +342,7 @@ mod tests {
 
                 associations.persist::<Author, _>(move |conn| {
                     Box::pin(async move {
-                        let author = Author::persist(&conn, author).await?;
+                        let author = persist::<Author>(conn).await?;
 
                         Ok(author)
                     })
@@ -401,7 +401,7 @@ mod tests {
 
                 associations.persist::<Post, _>(move |conn| {
                     Box::pin(async move {
-                        let post = Post::persist(&conn, post).await?;
+                        let post = persist::<Post>(conn).await?;
 
                         Ok(post)
                     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,6 @@ impl<Conn: 'static> Associations<Conn> {
         self.associations.push(AnyAssociation {
             entity_type: TypeId::of::<T>(),
             persist: Box::new(|conn| {
-                let conn = conn.clone();
                 Box::pin(async move {
                     let value = persist(conn).await?;
 


### PR DESCRIPTION
This PR adds initial support for associations.

Associations allow for automatically creating another entity when one is persisted. This can be used, for instance, to construct parent entities in a hierarchy.

There's still some rough edges in the API that I'd like to get ironed out, but right now it is functional.